### PR TITLE
Add util for saving/reporting screenshots

### DIFF
--- a/lib/synchronize.js
+++ b/lib/synchronize.js
@@ -52,6 +52,7 @@ class Driver extends Wrapper {
     this.navigate = Wrapper.wrap(_driver, 'navigate', val => new Navigation(val))
     this.switchTo = Wrapper.wrap(_driver, 'switchTo', val => new TargetLocator(val))
     this.setFileDetector = Wrapper.wrap(_driver, 'setFileDetector')
+    this._sync = true
   }
 
   findElements(by) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,52 @@
+const fs = require('fs')
+const path = require('path')
+
+/**
+ * Saves current screenshot from driver.
+ * fileName is resolved from testTitle and saved under given directory.
+ *
+ * And the same is reported to test-result report with `image` type.
+ *
+ * Ex:
+ *  if (this.currentTest.state !== 'failed') {
+ *    wdUtil.saveScreenshot(driver, './', this.currentTest.title)
+ *  }
+ *
+ * @param {Driver} driver sync'ed webdriver
+ * @param {String} dir directory under which screenshot will be stored
+ * @param {String} testTitle current test title for resolving fileName
+ */
+function saveScreenshot(driver, dir, testTitle) {
+  const data = driver.takeScreenshot()
+  const fileName = testTitle.replace(/[^a-zA-Z0-9]/g, '_')
+    .concat('_')
+    .concat(new Date().getTime())
+    .concat('.png')
+
+  const fullPath = path.resolve(dir, fileName)
+  fs.writeFileSync(fullPath, data, 'base64')
+  reportOutput({
+    type: 'image',
+    name: fileName,
+    file: fullPath
+  })
+}
+
+/**
+ * Add given object to current test report; Input should be a map with type field.
+ * obj.type can be any arbitrary name to identify in the report.
+ *
+ * Usecases are: save webdriver screenshot on test failure and report
+ * file locatio to test report.
+ *
+ * @param {Object} obj
+ */
+function reportOutput(obj) {
+  if (!obj || !obj.type) {
+    throw new Error('Invalid output or missing type field')
+  }
+  process.emit('testoutput', obj)
+}
+
+exports.saveScreenshot = saveScreenshot
+exports.reportOutput = reportOutput


### PR DESCRIPTION
Added `util` module for saving screenshots and reporting output details to reporters. 

Ex: 
```
  import wdUtil from 'webdriver-runner/util'
  ...
  test.afterEach(function() {
    if (this.currentTest.state !== 'failed') {
      wdUtil.saveScreenshot(driver, './', this.currentTest.title)
    }
  })
```

This method does following things:
* Resolve fileName based on test-title 
* Resolve absolute file based on given directory
* Retrieve data and store 
* Report to test-result store for further references/ html reporters. 
