### PR TITLE
Add delegate method to get actual element

### DIFF
--- a/examples/homepage.test.js
+++ b/examples/homepage.test.js
@@ -4,7 +4,7 @@ import webdriverProvider from './webdriver-provider'
 import test from 'webdriver-runner/testing'
 import wdUtil from 'webdriver-runner/util'
 import * as syncr from 'webdriver-runner/synchronize'
-import { By } from 'selenium-webdriver'
+import { By, until } from 'selenium-webdriver'
 
 test.describe('Github home page', function() {
   let driver
@@ -19,6 +19,12 @@ test.describe('Github home page', function() {
     const link = driver.findElements(By.css('.HeaderNavlink'))[4]
     // Navigate to pricing page
     link.click()
+
+    // Use delegate() method to return actual WebElement, instead of wrapper
+    // This method is useful incase of 'Until.*' methods
+    const ele = driver.findElement(By.css('.plans-card'))
+    driver.wait(until.elementIsVisible(ele.delegate()))
+
     // Query available plans
     const plans = driver.findElements(By.css('.plans-card'))
     console.log('Number of plans available: ', plans.length)

--- a/examples/package.json
+++ b/examples/package.json
@@ -4,7 +4,8 @@
   "description": "basic examples on webdriver-runner",
   "main": "runner.js",
   "scripts": {
-    "test": "node runner.js"
+    "test": "node runner.js",
+    "copy": "cp -r ../lib/* node_modules/webdriver-runner"
   },
   "keywords": [
     "webdriver",

--- a/lib/synchronize.js
+++ b/lib/synchronize.js
@@ -57,6 +57,7 @@ class Driver extends Wrapper {
     this.switchTo = Wrapper.wrap(_driver, 'switchTo', val => new TargetLocator(val))
     this.setFileDetector = Wrapper.wrap(_driver, 'setFileDetector')
     this.wait = Wrapper.wrapAsync(_driver, 'wait', (val, obj) => new Element(val, obj))
+    this.delegate = () => _driver
     this._sync = true
   }
 
@@ -82,6 +83,7 @@ class Element extends Wrapper {
     super(_ele, ELEMENT_METHODS)
     this.ele = _ele
     this.getDriver = () => _driver
+    this.delegate = () => _ele
   }
 }
 
@@ -94,6 +96,7 @@ class Actions extends Wrapper {
     this.perform = Wrapper.wrapAsync(actions, 'perform')
     this.keyboard = Wrapper.wrapAsync(actions, 'keyboard')
     this.pointer = Wrapper.wrapAsync(actions, 'pointer')
+    this.delegate = () => actions
   }
 }
 
@@ -105,6 +108,7 @@ class Options extends Wrapper {
     super(options, OPTIONS_METHODS)
     this.window = Wrapper.wrapAsync(options, 'window', val => new Window(val))
     this.logs = Wrapper.wrapAsync(options, 'logs', val => new Logs(val))
+    this.delegate = () => options
   }
 }
 
@@ -113,6 +117,7 @@ const WINDOW_METHODS = 'fullscreen,getRect,maximize,minimize,setRect'
 class Window extends Wrapper {
   constructor(window) {
     super(window, WINDOW_METHODS)
+    this.delegate = () => window
   }
 }
 
@@ -121,6 +126,7 @@ const LOGS_METHODS = 'get,getAvailableLogTypes'
 class Logs extends Wrapper {
   constructor(logs) {
     super(logs, LOGS_METHODS)
+    this.delegate = () => logs
   }
 }
 
@@ -129,6 +135,7 @@ const NAV_METHODS = 'back,forward,refresh,to'
 class Navigation extends Wrapper {
   constructor(navigation) {
     super(navigation, NAV_METHODS)
+    this.delegate = () => navigation
   }
 }
 
@@ -137,6 +144,7 @@ const TAR_LOC_GET_METHODS = 'activeElement,alert,defaultContent,frame,parentFram
 class TargetLocator extends Wrapper {
   constructor(target) {
     super(target, TAR_LOC_GET_METHODS)
+    this.delegate = () => target
   }
 }
 


### PR DESCRIPTION
Added `delegate` method in all wrapper classes to get the actual object. this is useful incase webdriver-api need Promise based objects. One use-case is for `Until` methods.

```
// Use delegate() method to return actual WebElement, instead of wrapper
// This method is useful incase of 'Until.*' methods
const ele = driver.findElement(By.css('.plans-card'))
driver.wait(until.elementIsVisible(ele.delegate()))
```

